### PR TITLE
Fix MS Windows compatibility and bump version for snapshot release (main)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.irods</groupId>
 	<artifactId>irods4j</artifactId>
-	<version>0.2.0</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>irods4j</name>

--- a/src/main/java/org/irods/irods4j/high_level/vfs/IRODSCollectionIterator.java
+++ b/src/main/java/org/irods/irods4j/high_level/vfs/IRODSCollectionIterator.java
@@ -1,7 +1,6 @@
 package org.irods.irods4j.high_level.vfs;
 
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.List;
 
@@ -316,7 +315,7 @@ public class IRODSCollectionIterator implements Iterable<CollectionEntry> {
 			}
 
 			e.dataId = row.get(0);
-			e.path = Paths.get(iter.logicalPath, row.get(1)).toString();
+			e.path = String.join("/", iter.logicalPath, row.get(1));
 			e.dataSize = Long.parseLong(row.get(2));
 			e.checksum = row.get(3);
 			e.dataMode = Integer.parseInt(row.get(4));

--- a/src/main/java/org/irods/irods4j/high_level/vfs/IRODSReplicas.java
+++ b/src/main/java/org/irods/irods4j/high_level/vfs/IRODSReplicas.java
@@ -1,7 +1,6 @@
 package org.irods.irods4j.high_level.vfs;
 
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 
@@ -63,9 +62,8 @@ public class IRODSReplicas {
 		throwIfNullOrEmpty(logicalPath, "Path is null or empty");
 		throwIfLessThanLowerBound(replicaNumber, 0, "Replica number is less than 0");
 
-		var p = Paths.get(logicalPath);
-		var collName = p.getParent().toString();
-		var dataName = p.getFileName().toString();
+		var collName = LogicalPath.parentPath(logicalPath);
+		var dataName = LogicalPath.objectName(logicalPath);
 
 		var query = "select DATA_SIZE where COLL_NAME = '%s' and DATA_NAME = '%s' and DATA_REPL_NUM = '%d'";
 		var rows = IRODSQuery.executeGenQuery2(comm, String.format(query, collName, dataName, replicaNumber));
@@ -96,9 +94,8 @@ public class IRODSReplicas {
 		throwIfNullOrEmpty(logicalPath, "Path is null or empty");
 		throwIfNullOrEmpty(leafResourceName, "Leaf resource is null or empty");
 
-		var p = Paths.get(logicalPath);
-		var collName = p.getParent().toString();
-		var dataName = p.getFileName().toString();
+		var collName = LogicalPath.parentPath(logicalPath);
+		var dataName = LogicalPath.objectName(logicalPath);
 
 		var query = "select DATA_SIZE where COLL_NAME = '%s' and DATA_NAME = '%s' and RESC_NAME = '%s'";
 		var rows = IRODSQuery.executeGenQuery2(comm, String.format(query, collName, dataName, leafResourceName));
@@ -714,9 +711,8 @@ public class IRODSReplicas {
 		throwIfNullOrEmpty(logicalPath, "Path is null or empty");
 		throwIfLessThanLowerBound(replicaNumber, 0, "Replica number is less than 0");
 
-		var p = Paths.get(logicalPath);
-		var collName = p.getParent().toString();
-		var dataName = p.getFileName().toString();
+		var collName = LogicalPath.parentPath(logicalPath);
+		var dataName = LogicalPath.objectName(logicalPath);
 
 		var query = "select DATA_MODIFY_TIME where COLL_NAME = '%s' and DATA_NAME = '%s' and DATA_REPL_NUM = '%d'";
 		var rows = IRODSQuery.executeGenQuery2(comm, String.format(query, collName, dataName, replicaNumber));
@@ -748,9 +744,8 @@ public class IRODSReplicas {
 		throwIfNullOrEmpty(logicalPath, "Path is null or empty");
 		throwIfNullOrEmpty(leafResourceName, "Resource is null or empty");
 
-		var p = Paths.get(logicalPath);
-		var collName = p.getParent().toString();
-		var dataName = p.getFileName().toString();
+		var collName = LogicalPath.parentPath(logicalPath);
+		var dataName = LogicalPath.objectName(logicalPath);
 
 		var query = "select DATA_MODIFY_TIME where COLL_NAME = '%s' and DATA_NAME = '%s' and RESC_NAME = '%s'";
 		var rows = IRODSQuery.executeGenQuery2(comm, String.format(query, collName, dataName, leafResourceName));
@@ -858,9 +853,8 @@ public class IRODSReplicas {
 		throwIfNullOrEmpty(logicalPath, "Path is null or empty");
 		throwIfNullOrEmpty(leafResourceName, "Resource is null or empty");
 
-		var p = Paths.get(logicalPath);
-		var collName = p.getParent().toString();
-		var dataName = p.getFileName().toString();
+		var collName = LogicalPath.parentPath(logicalPath);
+		var dataName = LogicalPath.objectName(logicalPath);
 
 		var query = "select DATA_REPL_NUM where COLL_NAME = '%s' and DATA_NAME = '%s' and RESC_NAME = '%s'";
 		var rows = IRODSQuery.executeGenQuery2(comm, String.format(query, collName, dataName, leafResourceName));
@@ -892,9 +886,8 @@ public class IRODSReplicas {
 		throwIfNullOrEmpty(logicalPath, "Path is null or empty");
 		throwIfLessThanLowerBound(replicaNumber, 0, "Replica number is less than 0");
 
-		var p = Paths.get(logicalPath);
-		var collName = p.getParent().toString();
-		var dataName = p.getFileName().toString();
+		var collName = LogicalPath.parentPath(logicalPath);
+		var dataName = LogicalPath.objectName(logicalPath);
 
 		var query = "select RESC_NAME where COLL_NAME = '%s' and DATA_NAME = '%s' and DATA_REPL_NUM = '%d'";
 		var rows = IRODSQuery.executeGenQuery2(comm, String.format(query, collName, dataName, replicaNumber));
@@ -926,9 +919,8 @@ public class IRODSReplicas {
 		throwIfNullOrEmpty(logicalPath, "Path is null or empty");
 		throwIfLessThanLowerBound(replicaNumber, 0, "Replica number is less than 0");
 
-		var p = Paths.get(logicalPath);
-		var collName = p.getParent().toString();
-		var dataName = p.getFileName().toString();
+		var collName = LogicalPath.parentPath(logicalPath);
+		var dataName = LogicalPath.objectName(logicalPath);
 
 		var query = "select DATA_ID where COLL_NAME = '%s' and DATA_NAME = '%s' and DATA_REPL_NUM = '%d'";
 		return !IRODSQuery.executeGenQuery2(comm, String.format(query, collName, dataName, replicaNumber)).isEmpty();
@@ -955,9 +947,8 @@ public class IRODSReplicas {
 		throwIfNullOrEmpty(logicalPath, "Path is null or empty");
 		throwIfNullOrEmpty(leafResourceName, "Resource is null or empty");
 
-		var p = Paths.get(logicalPath);
-		var collName = p.getParent().toString();
-		var dataName = p.getFileName().toString();
+		var collName = LogicalPath.parentPath(logicalPath);
+		var dataName = LogicalPath.objectName(logicalPath);
 
 		var query = "select DATA_ID where COLL_NAME = '%s' and DATA_NAME = '%s' and RESC_NAME = '%s'";
 		return !IRODSQuery.executeGenQuery2(comm, String.format(query, collName, dataName, leafResourceName)).isEmpty();

--- a/src/main/java/org/irods/irods4j/high_level/vfs/LogicalPath.java
+++ b/src/main/java/org/irods/irods4j/high_level/vfs/LogicalPath.java
@@ -1,0 +1,82 @@
+package org.irods.irods4j.high_level.vfs;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * This class provides support methods for operating on iRODS logical paths.
+ * <p>The methods exposed by this class assume paths are non-null.</p>
+ *
+ * @since 0.3.0
+ */
+public final class LogicalPath {
+
+	private LogicalPath() {
+	}
+
+	/**
+	 * Returns whether the logical path represents an absolute path.
+	 *
+	 * @param path The logical path to operate on.
+	 * @since 0.3.0
+	 */
+	public static boolean isAbsolute(String path) {
+		return path.startsWith("/");
+	}
+
+	/**
+	 * Returns the parent path of the given logical path.
+	 * <p>Returns null if the path is relative or no forward slash is found.</p>
+	 *
+	 * @param path The logical path to operate on.
+	 * @since 0.3.0
+	 */
+	public static String parentPath(String path) {
+		int lastSlash = path.lastIndexOf('/');
+		if (lastSlash <= 0) {
+			return isAbsolute(path) ? "/" : null;
+		}
+		return path.substring(0, lastSlash);
+	}
+
+	/**
+	 * Returns the farthest path element of the given logical path.
+	 * <p>Returns the given path if no forward slash is found.</p>
+	 *
+	 * @param path The logical path to operate on.
+	 * @since 0.3.0
+	 */
+	public static String objectName(String path) {
+		int lastSlash = path.lastIndexOf('/');
+		return (lastSlash == -1) ? path : path.substring(lastSlash + 1);
+	}
+
+	/**
+	 * Returns the list of segments which make up the logical path.
+	 *
+	 * @param path The logical path to operate on.
+	 * @since 0.3.0
+	 */
+	public static List<String> segments(String path) {
+		if ("/".equals(path)) {
+			var parts = new ArrayList<String>();
+			parts.add("/");
+			return parts;
+		}
+
+		var parts = Arrays.stream(path.split("/")).collect(Collectors.toList());
+
+		if (isAbsolute(path)) {
+			parts.set(0, "/");
+		}
+
+		if (path.endsWith("/")) {
+			parts.add("");
+		}
+
+		return parts;
+	}
+
+}

--- a/src/test/java/org/irods/irods4j/high_level/IRODSCollectionIteratorTest.java
+++ b/src/test/java/org/irods/irods4j/high_level/IRODSCollectionIteratorTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.nio.file.Paths;
 import java.util.ArrayList;
 
 import org.apache.logging.log4j.LogManager;
@@ -57,7 +56,7 @@ class IRODSCollectionIteratorTest {
 	@Test
 	void testIteratingOverCollectionHoldingAllHomeCollections() throws Exception {
 		var paths = new ArrayList<String>();
-		var collection = Paths.get("/", zone, "home").toString();
+		var collection = '/' + String.join("/", zone, "home");
 		for (var e : new IRODSCollectionIterator(conn.getRcComm(), collection)) {
 			paths.add(e.path());
 		}
@@ -68,7 +67,7 @@ class IRODSCollectionIteratorTest {
 	@Test
 	void testIteratingOverAnEmptyCollection() throws Exception {
 		var paths = new ArrayList<String>();
-		var collection = Paths.get("/", zone, "home", "public").toString();
+		var collection = '/' + String.join("/", zone, "home", "public");
 		for (var e : new IRODSCollectionIterator(conn.getRcComm(), collection)) {
 			paths.add(e.path());
 		}
@@ -78,7 +77,7 @@ class IRODSCollectionIteratorTest {
 	@Test
 	void testConstructingAnIteratorFromADataObjectPathResultsInANullIterator() throws Exception {
 		var dataObjectName = "testIteratingUsingADataObjectPathResultsInAnException";
-		var path = Paths.get("/", zone, "home", username, dataObjectName).toString();
+		var path = '/' + String.join("/", zone, "home", username, dataObjectName);
 
 		try {
 			// Create the data object.

--- a/src/test/java/org/irods/irods4j/high_level/IRODSConnectionTest.java
+++ b/src/test/java/org/irods/irods4j/high_level/IRODSConnectionTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.nio.file.Paths;
 import java.util.Optional;
 
 import org.apache.logging.log4j.LogManager;
@@ -114,7 +113,7 @@ class IRODSConnectionTest {
 				// Stat the admin's home collection. This will fail due to the test user not
 				// having permission to see the target collection.
 				var input = new DataObjInp_PI();
-				input.objPath = Paths.get("/", zone, "home", username).toString();
+				input.objPath = '/' + String.join("/", zone, "home", username);
 				input.KeyValPair_PI = new KeyValPair_PI();
 				var output = new Reference<RodsObjStat_PI>();
 				var ec = IRODSApi.rcObjStat(conn.getRcComm(), input, output);
@@ -123,7 +122,7 @@ class IRODSConnectionTest {
 
 				// Stat the test user's home collection. This will succeed because the test user
 				// has the appropriate permissions for viewing the collection.
-				input.objPath = Paths.get("/", zone, "home", testUser.name).toString();
+				input.objPath = '/' + String.join("/", zone, "home", testUser.name);
 				ec = IRODSApi.rcObjStat(conn.getRcComm(), input, output);
 				assertEquals(ec, 2);
 			} finally {

--- a/src/test/java/org/irods/irods4j/high_level/IRODSDataObjectStreamTest.java
+++ b/src/test/java/org/irods/irods4j/high_level/IRODSDataObjectStreamTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.Executors;
@@ -67,9 +66,7 @@ class IRODSDataObjectStreamTest {
 
 	@Test
 	void testDataObjectStreamCapturesReplicaNumberAndReplicaToken() throws Exception {
-		var logicalPath = Paths
-				.get("/", zone, "home", username, "testDataObjectStreamCapturesReplicaNumberAndReplicaToken.txt")
-				.toString();
+		var logicalPath = '/' + String.join("/", zone, "home", username, "testDataObjectStreamCapturesReplicaNumberAndReplicaToken.txt");
 
 		var in = new IRODSDataObjectStream();
 		in.open(comm, logicalPath, OpenFlags.O_CREAT | OpenFlags.O_WRONLY);
@@ -90,7 +87,7 @@ class IRODSDataObjectStreamTest {
 
 	@Test
 	void testReadingAndWritingUsingInputOutputStreams() throws IOException, IRODSException {
-		var logicalPath = Paths.get("/", zone, "home", username, "testInputOutputStreamImplementation").toString();
+		var logicalPath = '/' + String.join("/", zone, "home", username, "testInputOutputStreamImplementation");
 
 		try {
 			var truncate = true;
@@ -120,8 +117,7 @@ class IRODSDataObjectStreamTest {
 
 	@Test
 	void testReadingAndWritingUsingInputOutputStreamsAndVerySmallInternalBuffer() throws IOException, IRODSException {
-		var logicalPath = Paths.get("/", zone, "home", username,
-				"testReadingAndWritingUsingInputOutputStreamsAndVerySmallInternalBuffer").toString();
+		var logicalPath = '/' + String.join("/", zone, "home", username, "testReadingAndWritingUsingInputOutputStreamsAndVerySmallInternalBuffer");
 
 		try {
 			// The buffer size used by the input/output streams. The size is intentionally
@@ -157,7 +153,7 @@ class IRODSDataObjectStreamTest {
 
 	@Test
 	void testParallelTransferOverPort1247() throws Exception {
-		var logicalPath = Paths.get("/", zone, "home", username, "testParallelTransferOverPort1247.txt").toString();
+		var logicalPath = '/' + String.join("/", zone, "home", username, "testParallelTransferOverPort1247.txt");
 		var streamCount = 3;
 
 		try (var connPool = new IRODSConnectionPool(streamCount)) {
@@ -181,9 +177,9 @@ class IRODSDataObjectStreamTest {
 				var replicaNumber = stream1.getReplicaNumber();
 
 				try (var stream2 = new IRODSDataObjectStream();
-						var stream3 = new IRODSDataObjectStream();
-						var conn2 = connPool.getConnection();
-						var conn3 = connPool.getConnection()) {
+					 var stream3 = new IRODSDataObjectStream();
+					 var conn2 = connPool.getConnection();
+					 var conn3 = connPool.getConnection()) {
 					// Open the secondary streams using the replica token and replica number from
 					// the primary stream.
 					stream2.open(conn2.getRcComm(), replicaToken, logicalPath, replicaNumber, OpenFlags.O_WRONLY);

--- a/src/test/java/org/irods/irods4j/high_level/IRODSFilesystemTest.java
+++ b/src/test/java/org/irods/irods4j/high_level/IRODSFilesystemTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
-import java.nio.file.Paths;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -54,15 +53,14 @@ class IRODSFilesystemTest {
 
 	@Test
 	void testCreateAndDeleteCollection() throws Exception {
-		var collection = Paths.get("/", zone, "home", username, "testCreateAndDeleteCollection").toString();
+		var collection = '/' + String.join("/", zone, "home", username, "testCreateAndDeleteCollection");
 		assertTrue(IRODSFilesystem.createCollection(conn.getRcComm(), collection));
 		assertTrue(IRODSFilesystem.remove(conn.getRcComm(), collection, RemoveOptions.NO_TRASH));
 	}
 
 	@Test
 	void testModifyingTheInheritanceFlagOfACollection() throws IOException, IRODSException {
-		var collection = Paths.get("/", zone, "home", username, "testModifyingTheInheritanceFlagOfACollection")
-				.toString();
+		var collection = '/' + String.join("/", zone, "home", username, "testModifyingTheInheritanceFlagOfACollection");
 
 		try {
 			// Create a new collection.
@@ -88,7 +86,7 @@ class IRODSFilesystemTest {
 
 	@Test
 	void testRenameACollection() throws IOException, IRODSException {
-		var collection = Paths.get("/", zone, "home", username, "testRenameACollection").toString();
+		var collection = '/' + String.join("/", zone, "home", username, "testRenameACollection");
 		String collToRemove = collection;
 
 		try {
@@ -117,35 +115,35 @@ class IRODSFilesystemTest {
 
 	@Test
 	void testCopyADataObjectUsingCopyDataObjectFunction() throws Exception {
-		var sandbox = Paths.get("/", zone, "home", username, "testCopyADataObjectUsingCopyDataObjectFunction");
+		var sandbox = '/' + String.join("/", zone, "home", username, "testCopyADataObjectUsingCopyDataObjectFunction");
 
 		try {
-			assertTrue(IRODSFilesystem.createCollection(conn.getRcComm(), sandbox.toString()));
+			assertTrue(IRODSFilesystem.createCollection(conn.getRcComm(), sandbox));
 
 			// Create a data object.
-			var from = sandbox.resolve("data_object1");
+			var from = String.join("/", sandbox, "data_object1");
 			try (var stream = new IRODSDataObjectStream()) {
-				stream.open(conn.getRcComm(), from.toString(), OpenFlags.O_CREAT | OpenFlags.O_WRONLY);
+				stream.open(conn.getRcComm(), from, OpenFlags.O_CREAT | OpenFlags.O_WRONLY);
 			}
-			var fromStatus = IRODSFilesystem.status(conn.getRcComm(), from.toString());
+			var fromStatus = IRODSFilesystem.status(conn.getRcComm(), from);
 			assertTrue(IRODSFilesystem.exists(fromStatus));
 			assertTrue(IRODSFilesystem.isDataObject(fromStatus));
 
 			// Copy the data object and show that it exists.
-			var to = sandbox.resolve("data_object2");
-			assertTrue(IRODSFilesystem.copyDataObject(conn.getRcComm(), from.toString(), to.toString()));
+			var to = String.join("/", sandbox, "data_object2");
+			assertTrue(IRODSFilesystem.copyDataObject(conn.getRcComm(), from, to));
 
-			var toStatus = IRODSFilesystem.status(conn.getRcComm(), to.toString());
+			var toStatus = IRODSFilesystem.status(conn.getRcComm(), to);
 			assertTrue(IRODSFilesystem.exists(toStatus));
 			assertTrue(IRODSFilesystem.isDataObject(toStatus));
 		} finally {
-			IRODSFilesystem.removeAll(conn.getRcComm(), sandbox.toString(), RemoveOptions.NO_TRASH);
+			IRODSFilesystem.removeAll(conn.getRcComm(), sandbox, RemoveOptions.NO_TRASH);
 		}
 	}
 
 	@Test
 	void testListPermissionsOnDataObject() throws Exception {
-		var path = Paths.get("/", zone, "home", username, "testListPermissionsOnDataObject").toString();
+		var path = '/' + String.join("/", zone, "home", username, "testListPermissionsOnDataObject");
 
 		// Create a new data object.
 		try (var out = new IRODSDataObjectStream()) {

--- a/src/test/java/org/irods/irods4j/high_level/IRODSMetadataTest.java
+++ b/src/test/java/org/irods/irods4j/high_level/IRODSMetadataTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -57,7 +56,7 @@ class IRODSMetadataTest {
 	@Test
 	void testAddSetRemoveMetadataForDataObject() throws IOException, IRODSException {
 		var dataName = "testAddSetRemoveMetadataForDataObject";
-		var logicalPath = Paths.get("/", zone, "home", username, dataName).toString();
+		var logicalPath = '/' + String.join("/", zone, "home", username, dataName);
 		var attrName = "data_object_attr_name";
 		var attrValue = "data_object_attr_value";
 
@@ -103,7 +102,7 @@ class IRODSMetadataTest {
 	@Test
 	void testAddSetRemoveMetadataForDataObjectAsAdmin() throws IOException, IRODSException {
 		var dataName = "testAddSetRemoveMetadataForDataObject";
-		var logicalPath = Paths.get("/", zone, "home", username, dataName).toString();
+		var logicalPath = '/' + String.join("/", zone, "home", username, dataName);
 		var attrName = "data_object_attr_name";
 		var attrValue = "data_object_attr_value";
 
@@ -186,7 +185,7 @@ class IRODSMetadataTest {
 
 	@Test
 	void testAddSetRemoveMetadataForCollection() throws IOException, IRODSException {
-		var collection = Paths.get("/", zone, "home", username).toString();
+		var collection = '/' + String.join("/", zone, "home", username);
 		var attrName = "collection_attr_name";
 		var attrValue = "collection_attr_value";
 
@@ -222,7 +221,7 @@ class IRODSMetadataTest {
 
 	@Test
 	void testAddSetRemoveMetadataForCollectionAsAdmin() throws IOException, IRODSException {
-		var collection = Paths.get("/", zone, "home", username).toString();
+		var collection = '/' + String.join("/", zone, "home", username);
 		var attrName = "collection_attr_name";
 		var attrValue = "collection_attr_value";
 

--- a/src/test/java/org/irods/irods4j/high_level/IRODSRecursiveCollectionIteratorTest.java
+++ b/src/test/java/org/irods/irods4j/high_level/IRODSRecursiveCollectionIteratorTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.nio.file.Paths;
 import java.util.ArrayList;
 
 import org.apache.logging.log4j.LogManager;
@@ -57,7 +56,7 @@ class IRODSRecursiveCollectionIteratorTest {
 	@Test
 	void testIteratingOverCollectionHoldingAllHomeCollections() throws Exception {
 		var paths = new ArrayList<String>();
-		var collection = Paths.get("/", zone, "home").toString();
+		var collection = '/' + String.join("/", zone, "home");
 		for (var e : new IRODSRecursiveCollectionIterator(conn.getRcComm(), collection)) {
 			paths.add(e.path());
 		}
@@ -68,7 +67,7 @@ class IRODSRecursiveCollectionIteratorTest {
 	@Test
 	void testIteratingOverAnEmptyCollection() throws Exception {
 		var paths = new ArrayList<String>();
-		var collection = Paths.get("/", zone, "home", "public").toString();
+		var collection = '/' + String.join("/", zone, "home", "public");
 		for (var e : new IRODSRecursiveCollectionIterator(conn.getRcComm(), collection)) {
 			paths.add(e.path());
 		}
@@ -78,7 +77,7 @@ class IRODSRecursiveCollectionIteratorTest {
 	@Test
 	void testConstructingAnIteratorFromADataObjectPathResultsInANullIterator() throws Exception {
 		var dataObjectName = "testIteratingUsingADataObjectPathResultsInAnException";
-		var path = Paths.get("/", zone, "home", username, dataObjectName).toString();
+		var path = '/' + String.join("/", zone, "home", username, dataObjectName);
 
 		try {
 			// Create the data object.

--- a/src/test/java/org/irods/irods4j/high_level/IRODSReplicasTest.java
+++ b/src/test/java/org/irods/irods4j/high_level/IRODSReplicasTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
 import java.util.Optional;
 
 import org.apache.logging.log4j.LogManager;
@@ -63,8 +62,7 @@ class IRODSReplicasTest {
 
 	@Test
 	void testCalculateChecksumForReplicaAsAdminWithoutPermissionsOnDataObject() throws Exception {
-		var logicalPath = Paths.get("/", zone, "home", rodsuser.name, "testUpdateModificationTimeOfReplicaAsAdmin.txt")
-				.toString();
+		var logicalPath = '/' + String.join("/", zone, "home", rodsuser.name, "testUpdateModificationTimeOfReplicaAsAdmin.txt");
 		var rodsuserPassword = "thepassword";
 
 		try {

--- a/src/test/java/org/irods/irods4j/high_level/LogicalPathTest.java
+++ b/src/test/java/org/irods/irods4j/high_level/LogicalPathTest.java
@@ -1,0 +1,61 @@
+package org.irods.irods4j.high_level;
+
+import org.irods.irods4j.high_level.vfs.LogicalPath;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class LogicalPathTest {
+
+	@Test
+	void testLogicalPathIsAbsolute() {
+		Assertions.assertTrue(LogicalPath.isAbsolute("/"));
+		Assertions.assertTrue(LogicalPath.isAbsolute("/tempZone"));
+		Assertions.assertTrue(LogicalPath.isAbsolute("/tempZone/home"));
+
+		Assertions.assertFalse(LogicalPath.isAbsolute(""));
+		Assertions.assertFalse(LogicalPath.isAbsolute(" /"));
+		Assertions.assertFalse(LogicalPath.isAbsolute("tempZone"));
+		Assertions.assertFalse(LogicalPath.isAbsolute("tempZone/home/rods"));
+		Assertions.assertFalse(LogicalPath.isAbsolute("."));
+		Assertions.assertFalse(LogicalPath.isAbsolute(".."));
+
+		Assertions.assertThrows(NullPointerException.class, () -> LogicalPath.isAbsolute(null));
+	}
+
+	@Test
+	void testGetParentPathFromLogicalPath() {
+		Assertions.assertNull(LogicalPath.parentPath(""));
+
+		Assertions.assertEquals("/", LogicalPath.parentPath("/"));
+		Assertions.assertEquals("/", LogicalPath.parentPath("/tempZone"));
+		Assertions.assertEquals("/tempZone", LogicalPath.parentPath("/tempZone/home"));
+		Assertions.assertEquals("/tempZone/home", LogicalPath.parentPath("/tempZone/home/rods"));
+
+		Assertions.assertThrows(NullPointerException.class, () -> LogicalPath.parentPath(null));
+	}
+
+	@Test
+	void testGetObjectNameFromLogicalPath() {
+		Assertions.assertEquals("", LogicalPath.objectName(""));
+		Assertions.assertEquals("", LogicalPath.objectName("/"));
+		Assertions.assertEquals("tempZone", LogicalPath.objectName("/tempZone"));
+		Assertions.assertEquals("home", LogicalPath.objectName("/tempZone/home"));
+		Assertions.assertEquals("file.txt", LogicalPath.objectName("/tempZone/home/rods/file.txt"));
+		Assertions.assertEquals("", LogicalPath.objectName("/tempZone/home/rods/"));
+
+		Assertions.assertThrows(NullPointerException.class, () -> LogicalPath.objectName(null));
+	}
+
+	@Test
+	void testSplitLogicalPathIntoPathElements() {
+		Assertions.assertEquals(List.of(""), LogicalPath.segments(""));
+		Assertions.assertEquals(List.of("/"), LogicalPath.segments("/"));
+		Assertions.assertEquals(List.of("/", "tempZone", ""), LogicalPath.segments("/tempZone/"));
+		Assertions.assertEquals(List.of("/", "tempZone", ".", ".."), LogicalPath.segments("/tempZone/./.."));
+
+		Assertions.assertThrows(NullPointerException.class, () -> LogicalPath.segments(null));
+	}
+
+}

--- a/src/test/java/org/irods/irods4j/low_level/CollectionOperationsTest.java
+++ b/src/test/java/org/irods/irods4j/low_level/CollectionOperationsTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Optional;
 
@@ -44,7 +43,7 @@ class CollectionOperationsTest {
 	void testCreatingAndDeletingCollections() throws IOException {
 		// Create a new collection.
 		var input = new CollInpNew_PI();
-		input.collName = Paths.get("/", zone, "home", username, "irods4j_test_coll").toString();
+		input.collName = '/' + String.join("/", zone, "home", username, "irods4j_test_coll");
 		input.KeyValPair_PI = new KeyValPair_PI(); // Not necessary as shown through testing.
 		input.KeyValPair_PI.ssLen = 0; // Not necessary as shown through testing.
 

--- a/src/test/java/org/irods/irods4j/low_level/RcAtomicApplyAclOperationsTest.java
+++ b/src/test/java/org/irods/irods4j/low_level/RcAtomicApplyAclOperationsTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Optional;
@@ -41,7 +40,7 @@ class RcAtomicApplyAclOperationsTest {
 
 	@Test
 	void testRcAtomicApplyAclOperations() throws IOException {
-		var logicalPath = Paths.get("/", zone, "home", username).toString();
+		var logicalPath = '/' + String.join("/", zone, "home", username);
 
 		// Set the rodsadmin's permission to "write" on their home collection.
 		// Remember, they can always restore their permissions because they are

--- a/src/test/java/org/irods/irods4j/low_level/RcAtomicApplyMetadataOperationsTest.java
+++ b/src/test/java/org/irods/irods4j/low_level/RcAtomicApplyMetadataOperationsTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Optional;
@@ -43,7 +42,7 @@ class RcAtomicApplyMetadataOperationsTest {
 
 	@Test
 	void testAtomicApplyMetadataOperations() throws IOException {
-		var logicalPath = Paths.get("/", zone, "home", username).toString();
+		var logicalPath = '/' + String.join("/", zone, "home", username);
 		var attrName = "irods4j::atomic_attr_name";
 		var attrValue = "irods4j::atomic_attr_value";
 		var attrUnits = "irods4j::atomic_attr_units";

--- a/src/test/java/org/irods/irods4j/low_level/RcDataObjChksumTest.java
+++ b/src/test/java/org/irods/irods4j/low_level/RcDataObjChksumTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Optional;
@@ -42,7 +41,7 @@ class RcDataObjChksumTest {
 		assertNotNull(comm);
 		IRODSApi.rcAuthenticateClient(comm, "native", password);
 
-		dataObjPath = Paths.get("/", zone, "home", username, "createdByTestDataObjChksumSuite.txt").toString();
+		dataObjPath = '/' + String.join("/", zone, "home", username, "createdByTestDataObjChksumSuite.txt");
 
 		// Open a data object for writing.
 		var openInput = new DataObjInp_PI();

--- a/src/test/java/org/irods/irods4j/low_level/RcModAVUMetadataTest.java
+++ b/src/test/java/org/irods/irods4j/low_level/RcModAVUMetadataTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.Optional;
 
 import org.irods.irods4j.low_level.api.IRODSApi;
@@ -39,7 +38,7 @@ class RcModAVUMetadataTest {
 
 	@Test
 	void testAddingAndRemovingMetadata() throws IOException {
-		var collection = Paths.get("/", zone, "home", username).toString();
+		var collection = '/' + String.join("/", zone, "home", username);
 		var avuName = "irods4j::name";
 		var avuValue = "irods4j::value";
 		var avuUnit = "irods4j::unit";

--- a/src/test/java/org/irods/irods4j/low_level/RcModDataObjMetaTest.java
+++ b/src/test/java/org/irods/irods4j/low_level/RcModDataObjMetaTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Optional;
@@ -15,6 +14,7 @@ import java.util.Optional;
 import org.irods.irods4j.common.JsonUtil;
 import org.irods.irods4j.common.Reference;
 import org.irods.irods4j.common.XmlUtil;
+import org.irods.irods4j.high_level.vfs.LogicalPath;
 import org.irods.irods4j.low_level.api.IRODSApi;
 import org.irods.irods4j.low_level.api.IRODSApi.RcComm;
 import org.irods.irods4j.low_level.protocol.packing_instructions.DataObjInfo_PI;
@@ -46,7 +46,7 @@ class RcModDataObjMetaTest {
 		assertNotNull(comm);
 		IRODSApi.rcAuthenticateClient(comm, "native", password);
 
-		dataObjPath = Paths.get("/", zone, "home", username, "createdByTestModDataObjMeta.txt").toString();
+		dataObjPath = '/' + String.join("/", zone, "home", username, "createdByTestModDataObjMeta.txt");
 
 		// Open a data object for writing.
 		var openInput = new DataObjInp_PI();
@@ -132,9 +132,8 @@ class RcModDataObjMetaTest {
 		assertNotNull(output);
 		assertNotNull(output.value);
 
-		var logicalPath = Paths.get(dataObjPath);
-		var collName = logicalPath.getParent().toString();
-		var dataName = logicalPath.getFileName().toString();
+		var collName = LogicalPath.parentPath(dataObjPath);
+		var dataName = LogicalPath.objectName(dataObjPath);
 		assertTrue(output.value.contains(String.format("[\"%s\",\"%s\"]", collName, dataName)));
 
 	}

--- a/src/test/java/org/irods/irods4j/low_level/RcTicketAdminTest.java
+++ b/src/test/java/org/irods/irods4j/low_level/RcTicketAdminTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.Optional;
 
 import org.irods.irods4j.low_level.api.IRODSApi;
@@ -40,7 +39,7 @@ class RcTicketAdminTest {
 	@Test
 	void testCreateAndDeleteTicket() throws IOException {
 		var ticketName = "irods4j_ticket";
-		var collection = Paths.get("/", zone, "home", username).toString();
+		var collection = '/' + String.join("/", zone, "home", username);
 
 		// Create a new ticket on the user's home collection.
 		var input = new TicketAdminInp_PI();

--- a/src/test/java/org/irods/irods4j/low_level/RcTouchTest.java
+++ b/src/test/java/org/irods/irods4j/low_level/RcTouchTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Optional;
 
@@ -44,7 +43,7 @@ class RcTouchTest {
 
 	@Test
 	void testRcTouch() throws IOException {
-		var logicalPath = Paths.get("/", zone, "home", username).toString();
+		var logicalPath = '/' + String.join("/", zone, "home", username);
 		var mtime = 1700000000;
 
 		// Set the mtime of the rodsadmin's home collection to a specific value.

--- a/src/test/java/org/irods/irods4j/low_level/StreamOperationsTest.java
+++ b/src/test/java/org/irods/irods4j/low_level/StreamOperationsTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Optional;
@@ -49,7 +48,7 @@ class StreamOperationsTest {
 
 	@Test
 	void testStreamOperations() throws IOException {
-		var logicalPath = Paths.get("/", zone, "home", username, "testStreamOperations.txt");
+		var logicalPath = '/' + String.join("/", zone, "home", username, "testStreamOperations.txt");
 
 		// Open a data object for writing.
 		var openInput = new DataObjInp_PI();


### PR DESCRIPTION
Tests pass on Linux.

Will run tests on Windows ~tomorrow~.

This PR replaces use of java's Path library with a custom implementation called `LogicalPath`. This custom implementation provides a few methods to aid in the development of the irods4j library.

This PR does not change the public interface. It just fixes compatibility with Windows.