### PR TITLE
[#24] Use the same password for PAM plugin tests (main)

### DIFF
--- a/src/test/java/org/irods/irods4j/low_level/PamInteractiveAuthenticationTest.java
+++ b/src/test/java/org/irods/irods4j/low_level/PamInteractiveAuthenticationTest.java
@@ -30,7 +30,7 @@ class PamInteractiveAuthenticationTest {
     static int port = 1247;
     static String zone = "tempZone";
     static String username = "john";
-    static String password = "=i;r@o\\\\d&s";
+    static String password = "=i;r@o\\d&s";
     static RcComm comm;
     static boolean requireSecureConnection = true;
 


### PR DESCRIPTION
Discovered this typo while porting #108 to the java8 branch.